### PR TITLE
Fix Capper & Joiner bugs introduced by 856a70c

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -14,6 +14,7 @@
 Google Inc.
 Jeff R. Allen <jra@nella.org>
 Maksim Kochkin <maxxarts@gmail.com>
+Michael Fogleman <fogleman@gmail.com>
 Rémy Oudompheng <oudomphe@phare.normalesup.org>
 Roger Peppe <rogpeppe@gmail.com>
 Steven Edwards <steven@stephenwithav.com>

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -29,6 +29,7 @@
 Andrew Gerrand <adg@golang.org>
 Jeff R. Allen <jra@nella.org> <jeff.allen@gmail.com>
 Maksim Kochkin <maxxarts@gmail.com>
+Michael Fogleman <fogleman@gmail.com>
 Nigel Tao <nigeltao@golang.org>
 Rémy Oudompheng <oudomphe@phare.normalesup.org> <remyoudompheng@gmail.com>
 Rob Pike <r@golang.org>

--- a/raster/stroke.go
+++ b/raster/stroke.go
@@ -47,8 +47,8 @@ var RoundCapper Capper = CapperFunc(roundCapper)
 
 func roundCapper(p Adder, halfWidth fixed.Int26_6, pivot, n1 fixed.Point26_6) {
 	// The cubic Bézier approximation to a circle involves the magic number
-	// (√2 - 1) * 4/3, which is approximately 141/256.
-	const k = 141
+	// (√2 - 1) * 4/3, which is approximately 35/64.
+	const k = 35
 	e := pRot90CCW(n1)
 	side := pivot.Add(e)
 	start, end := pivot.Sub(n1), pivot.Add(n1)
@@ -111,8 +111,8 @@ func addArc(p Adder, pivot, n0, n1 fixed.Point26_6) {
 	// We approximate the arc by 0, 1, 2 or 3 45-degree quadratic segments plus
 	// a final quadratic segment from s to n1. Each 45-degree segment has
 	// control points {1, 0}, {1, tan(π/8)} and {1/√2, 1/√2} suitably scaled,
-	// rotated and translated. tan(π/8) is approximately 106/256.
-	const tpo8 = 106
+	// rotated and translated. tan(π/8) is approximately 27/64.
+	const tpo8 = 27
 	var s fixed.Point26_6
 	// We determine which octant the angle between n0 and n1 is in via three
 	// dot products. m0, m1 and m2 are n0 rotated clockwise by 45, 90 and 135


### PR DESCRIPTION
@nigeltao Do you take pull requests? Here's a fix. Let me know if anything else needs to be done.

Some constants were not updated properly when switching from raster.Point to fixed.26_6

Before the fix:

![before](https://cloud.githubusercontent.com/assets/520208/13148613/0ce66a0e-d62c-11e5-8aca-391dc39ba90e.png)

After the fix:

![after](https://cloud.githubusercontent.com/assets/520208/13148617/108682a2-d62c-11e5-991f-8e10133bb27f.png)
