### PR TITLE
Round scale to nearest 26.6 fixed point.

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -27,6 +27,7 @@
 # Please keep the list sorted.
 
 Andrew Gerrand <adg@golang.org>
+Dmitri Shuralyov <dmitshur@golang.org>
 Jeff R. Allen <jra@nella.org> <jeff.allen@gmail.com>
 Maksim Kochkin <maxxarts@gmail.com>
 Michael Fogleman <fogleman@gmail.com>

--- a/freetype.go
+++ b/freetype.go
@@ -260,7 +260,7 @@ func (c *Context) DrawString(s string, p fixed.Point26_6) (fixed.Point26_6, erro
 // recalc recalculates scale and bounds values from the font size, screen
 // resolution and font metrics, and invalidates the glyph cache.
 func (c *Context) recalc() {
-	c.scale = fixed.Int26_6(c.fontSize * c.dpi * (64.0 / 72.0))
+	c.scale = fixed.Int26_6(0.5 + (c.fontSize * c.dpi * 64 / 72))
 	if c.f == nil {
 		c.r.SetBounds(0, 0)
 	} else {

--- a/freetype.go
+++ b/freetype.go
@@ -78,7 +78,7 @@ type Context struct {
 // PointToFixed converts the given number of points (as in "a 12 point font")
 // into a 26.6 fixed point number of pixels.
 func (c *Context) PointToFixed(x float64) fixed.Int26_6 {
-	return fixed.Int26_6(x * float64(c.dpi) * (64.0 / 72.0))
+	return fixed.Int26_6(0.5 + (x * c.dpi * 64 / 72))
 }
 
 // drawContour draws the given closed contour with the given offset.

--- a/freetype_test.go
+++ b/freetype_test.go
@@ -67,6 +67,10 @@ func TestScaling(t *testing.T) {
 		want fixed.Int26_6
 	}{
 		{in: 12, want: fixed.I(12)},
+		{in: 11.992, want: fixed.I(12) - 1},
+		{in: 11.993, want: fixed.I(12)},
+		{in: 12.007, want: fixed.I(12)},
+		{in: 12.008, want: fixed.I(12) + 1},
 		{in: 86.4, want: fixed.Int26_6(86<<6 + 26)}, // Issue https://github.com/golang/freetype/issues/85.
 	} {
 		c.SetFontSize(tc.in)

--- a/freetype_test.go
+++ b/freetype_test.go
@@ -12,6 +12,8 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+
+	"golang.org/x/image/math/fixed"
 )
 
 func BenchmarkDrawString(b *testing.B) {
@@ -56,4 +58,23 @@ func BenchmarkDrawString(b *testing.B) {
 	runtime.ReadMemStats(&ms)
 	mallocs = ms.Mallocs - mallocs
 	b.Logf("%d iterations, %d mallocs per iteration\n", b.N, int(mallocs)/b.N)
+}
+
+func TestScaling(t *testing.T) {
+	c := NewContext()
+	for _, tc := range [...]struct {
+		in   float64
+		want fixed.Int26_6
+	}{
+		{in: 12, want: fixed.I(12)},
+		{in: 86.4, want: fixed.Int26_6(86<<6 + 26)}, // Issue https://github.com/golang/freetype/issues/85.
+	} {
+		c.SetFontSize(tc.in)
+		if got, want := c.scale, tc.want; got != want {
+			t.Errorf("scale after SetFontSize(%v) = %v, want %v", tc.in, got, want)
+		}
+		if got, want := c.PointToFixed(tc.in), tc.want; got != want {
+			t.Errorf("PointToFixed(%v) = %v, want %v", tc.in, got, want)
+		}
+	}
 }


### PR DESCRIPTION
With this change, the computation of the scale factor becomes
identical across the freetype and truetype packages, removing
deviations in the font metrics that are derived from scale.

Apply the same change to the Context.PointToFixed method to
keep it in sync.

The rounding computation is newer; it was introduced when the
truetype.Face type was added in commit 6deea2414309d03c665a7b.

Fixes #85.