### PR TITLE
prefer full/UCS4 sub-tables over BMP/UCS2 ones

### DIFF
--- a/truetype/truetype.go
+++ b/truetype/truetype.go
@@ -15,7 +15,7 @@
 //
 // To measure a TrueType font in ideal FUnit space, use scale equal to
 // font.FUnitsPerEm().
-package truetype // import "github.com/golang/freetype/truetype"
+package truetype
 
 import (
 	"fmt"


### PR DESCRIPTION
Some ttf files contain several sub-tables. For example, a ttf file may contain one unicodeEncodingBMPOnly table, one microsoftUCS2Encoding table, and one microsoftUCS4Encoding table. In this case, we choose microsoftUCS4Encoding as the best one. Since there are most valid codes in it.